### PR TITLE
Remove Brecht as conflicting pronunciation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@
 
 ## What is LaTeX ?
 
-LaTeX, which is pronounced «Lah-tech» or «Lay-tech» (to rhyme with «blech» or «Bertolt Brecht»), is a document preparation system for high-quality typesetting. It is most often used for medium-to-large technical or scientific documents but it can be used for almost any form of publishing.
+LaTeX, which is pronounced «Lah-tech» or «Lay-tech» (to rhyme with «blech»), is a document preparation system for high-quality typesetting. It is most often used for medium-to-large technical or scientific documents but it can be used for almost any form of publishing.
 
 ## Why use LaTeX ? 
 


### PR DESCRIPTION
Brecht is [bʀɛçt] in german, not [bʀɛkt] as it is in english, which could be confusing for german-speaking people.
