### PR TITLE
added identical language selection bar to all translation pages

### DIFF
--- a/Translation:Chinese.md
+++ b/Translation:Chinese.md
@@ -1,3 +1,11 @@
+[English](./readme.md) ·
+中文 ·
+[Español](./Translation:Spanish.md) ·
+[Português](./Translation:Portuguese.md) ·
+[Français](./Translation:French.md)
+
+---
+
 # 学习 LaTeX 从现在开始
 
 ![](https://upload.wikimedia.org/wikipedia/commons/9/92/LaTeX_logo.svg)

--- a/Translation:French.md
+++ b/Translation:French.md
@@ -1,15 +1,16 @@
+[English](./readme.md) ·
+[中文](./Translation:Chinese.md) ·
+[Español](./Translation:Spanish.md) ·
+[Português](./Translation:Portuguese.md) ·
+Français
+
+---
 
 # LaTeX en quelques minutes
 
 ![](https://upload.wikimedia.org/wikipedia/commons/9/92/LaTeX_logo.svg)
 
 **Note:** *Tout ce qui est écrit dans ce guide vient de ma propre expérience et des articles que j'ai lu. Je ne suis pas un professionnel ou expert, mais un étudiant qui apprécie beaucoup ce langage. N'importe qui peut ouvrir une discussion dans la section "issue", ou faire une "pull request". Si vous appréciez mon travail, vous pouvez me faire une [donation](#donation).*
-
-*Versions disponibles :*
-* [Anglais](readme.md)
-* [Chinois](./Translation:Chinese.md)
-* [Portugais](./Translation:Portuguese.md)
-* [Espagnol](./Translation:Spanish.md)
 
 ### Sommaire
 * [Qu'est ce que LaTeX?](#qu-est-ce-que-latex)

--- a/Translation:Portuguese.md
+++ b/Translation:Portuguese.md
@@ -1,3 +1,10 @@
+[English](./readme.md) ·
+[中文](./Translation:Chinese.md) ·
+[Español](./Translation:Spanish.md) ·
+Português ·
+[Français](./Translation:French.md)
+
+---
 
 # Comece com o LaTeX em minutos
 
@@ -6,9 +13,6 @@
 (Portuguese translator's acknowledgement: I tried to translate this guide as the original meaning of the author as much as i could. If you think the translation is inappropriate, please feel free to modify it or add missing stuff you think would make this guide better. If you like this guide, please share to more people.)
 
 **Aviso:** *Todo conteúdo escrito abaixo é de minha própria experiência na faculdade e da leitura de diversos materiais. Eu não sou nem professional nem especialista, mas um estudante com uma grande paixão pela linguagem. Qualquer um pode abrir uma discussão na seção issue, ou um pull request no caso de algo que deve ser modificado ou adicionado. Se você considera meu trabalho valioso, uma [doação](#doação) é muito apreciada.*
-
-*Versão em chinês disponível [Aqui](./Translation:Chinese.md)*  
-*Versão em espanhol disponível  [Aqui](./Translation:Spanish.md)*
 
 ### Tabela de Conteúdos
 * [O que é LaTeX?](#o-que-é-latex)

--- a/Translation:Spanish.md
+++ b/Translation:Spanish.md
@@ -1,3 +1,10 @@
+[English](./readme.md) ·
+[中文](./Translation:Chinese.md) ·
+Español ·
+[Português](./Translation:Portuguese.md) ·
+[Français](./Translation:French.md)
+
+---
 
 # Empieza con LaTeX en minutos
 
@@ -10,9 +17,6 @@
 
 
 
-
-*Versión en chino disponible: [aquí](./Translation:Chinese.md)*  
-*Versión en inglés disponible: [aquí](readme.md)*
 
 ### Table of Contents
 * [¿Qué es LaTeX?](#qué-es-latex)

--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,16 @@
+English ·
+[中文](./Translation:Chinese.md) ·
+[Español](./Translation:Spanish.md) ·
+[Português](./Translation:Portuguese.md) ·
+[Français](./Translation:French.md)
+
+---
 
 # Begin LaTeX in minutes
 
 ![](https://upload.wikimedia.org/wikipedia/commons/9/92/LaTeX_logo.svg)
 
 **Acknowledgement:** *Everything written below is from my own experience in college and after reading various materials. I am neither a professional nor expert, but a student who has great passion for the language. Anyone can open a discussion in the issue section, or a pull request in case something should be modified or added. If you consider my work valuable, a [donation](#donation) is much appreciated.*
-
-*[Chinese](./Translation:Chinese.md),
-[French](./Translation:French.md), [Portuguese](./Translation:Portuguese.md) and [Spanish](./Translation:Spanish.md) versions are available.*
 
 ### Table of Contents
 * [What is LaTeX?](#what-is-latex)


### PR DESCRIPTION
Should resolve #41. Translations are ordered as they were added over time, this seems fair and should simplify adding new translations - you simply append them in the end.