### PR TITLE
Add linking to German Translation

### DIFF
--- a/Translation:Chinese.md
+++ b/Translation:Chinese.md
@@ -3,7 +3,8 @@
 [Español](./Translation:Spanish.md) ·
 [Português](./Translation:Portuguese.md) ·
 [Français](./Translation:French.md) ·
-[Русский](./Translation:Russian.md)
+[Русский](./Translation:Russian.md) ·
+[Deutsch](./Translation:German.md)
 
 ---
 

--- a/Translation:French.md
+++ b/Translation:French.md
@@ -3,7 +3,8 @@
 [Español](./Translation:Spanish.md) ·
 [Português](./Translation:Portuguese.md) ·
 Français ·
-[Русский](./Translation:Russian.md)
+[Русский](./Translation:Russian.md) ·
+[Deutsch](./Translation:German.md)
 
 ---
 

--- a/Translation:German.md
+++ b/Translation:German.md
@@ -6,6 +6,8 @@
 [Русский](./Translation:Russian.md) ·
 Deutsch
 
+---
+
 # Mit LaTeX in Minuten beginnen
 
 ![](https://upload.wikimedia.org/wikipedia/commons/9/92/LaTeX_logo.svg)

--- a/Translation:Portuguese.md
+++ b/Translation:Portuguese.md
@@ -3,7 +3,8 @@
 [Español](./Translation:Spanish.md) ·
 Português ·
 [Français](./Translation:French.md) ·
-[Русский](./Translation:Russian.md)
+[Русский](./Translation:Russian.md) ·
+[Deutsch](./Translation:German.md)
 
 ---
 

--- a/Translation:Russian.md
+++ b/Translation:Russian.md
@@ -3,7 +3,8 @@
 [Español](./Translation:Spanish.md) ·
 [Português](./Translation:Portuguese.md) ·
 [Français](./Translation:French.md) ·
-Русский
+Русский ·
+[Deutsch](./Translation:German.md)
 
 ---
 

--- a/Translation:Spanish.md
+++ b/Translation:Spanish.md
@@ -3,7 +3,8 @@
 Español ·
 [Português](./Translation:Portuguese.md) ·
 [Français](./Translation:French.md) ·
-[Русский](./Translation:Russian.md)
+[Русский](./Translation:Russian.md) ·
+[Deutsch](./Translation:German.md)
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,8 @@ English ·
 [Español](./Translation:Spanish.md) ·
 [Português](./Translation:Portuguese.md) ·
 [Français](./Translation:French.md) ·
-[Русский](./Translation:Russian.md)
+[Русский](./Translation:Russian.md) ·
+[Deutsch](./Translation:German.md)
 
 ---
 


### PR DESCRIPTION
As @i-ky asked me to, I went and linked the German translation in the other pages.
I also found and fixed a missing divider in the beginning of the German translation page.